### PR TITLE
feat: enable B-tree deduplication for h3index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ avoid adding features or APIs which do not map onto the
 ## [Unreleased]
 
 - Use `PG_MODULE_MAGIC_EXT` macro in PostgreSQL 18 and later ([#203], [Andreas Karlsson])
+- [#213], Register the btree `equalimage` support function for `h3index`, enabling B-tree index deduplication. Existing indexes keep answering correctly across the upgrade, but `allequalimage` is stamped into the index at build time, so they only pick up the space saving on their next `REINDEX` ([#214], [@jmealo])
 
 ## [4.5.0] - 2026-06-08
 
@@ -358,6 +359,8 @@ avoid adding features or APIs which do not map onto the
 [#194]: https://github.com/postgis/h3-pg/pull/194
 [#197]: https://github.com/postgis/h3-pg/pull/197
 [#203]: https://github.com/postgis/h3-pg/pull/203
+[#213]: https://github.com/postgis/h3-pg/issues/213
+[#214]: https://github.com/postgis/h3-pg/pull/214
 [Abel Vázquez Montoro]: https://github.com/AbelVM
 [Andreas Karlsson]: https://github.com/jeltz
 [Darafei Praliaskouski]: https://github.com/Komzpa

--- a/h3/sql/install/11-opclass_btree.sql
+++ b/h3/sql/install/11-opclass_btree.sql
@@ -27,6 +27,12 @@ CREATE OR REPLACE FUNCTION h3index_sortsupport(internal)
 	LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 --@ internal
+CREATE OR REPLACE FUNCTION h3index_btequalimage(oid)
+	RETURNS boolean
+	AS 'h3', 'h3index_btequalimage'
+	LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+--@ internal
 CREATE OPERATOR CLASS h3index_ops DEFAULT FOR TYPE h3index USING btree AS
     OPERATOR  1  <  ,
     OPERATOR  2  <= ,
@@ -34,4 +40,5 @@ CREATE OPERATOR CLASS h3index_ops DEFAULT FOR TYPE h3index USING btree AS
     OPERATOR  4  >= ,
     OPERATOR  5  >  ,
     FUNCTION  1  h3index_cmp(h3index, h3index),
-    FUNCTION  2  h3index_sortsupport(internal);
+    FUNCTION  2  h3index_sortsupport(internal),
+    FUNCTION  4  h3index_btequalimage(oid);

--- a/h3/sql/updates/h3--4.5.0--unreleased.sql
+++ b/h3/sql/updates/h3--4.5.0--unreleased.sql
@@ -17,3 +17,10 @@
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "ALTER EXTENSION h3 UPDATE TO 'unreleased'" to load this file. \quit
+
+-- Add equalimage support function for btree opclass
+CREATE OR REPLACE FUNCTION h3index_btequalimage(oid) RETURNS boolean
+    AS 'h3', 'h3index_btequalimage' LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+ALTER OPERATOR FAMILY h3index_ops USING btree ADD
+    FUNCTION  4  (h3index, h3index) h3index_btequalimage(oid);

--- a/h3/src/opclass_btree.c
+++ b/h3/src/opclass_btree.c
@@ -41,6 +41,21 @@ h3index_cmp(PG_FUNCTION_ARGS)
 }
 
 
+/*
+ * Btree "equalimage" (support function 4).
+ *
+ * h3index is a fixed-width 64-bit pass-by-value type whose equality
+ * operator is bitwise identity, so deduplication is always safe.
+ * Mirrors btequalimage() in the PostgreSQL source.
+ */
+PGDLLEXPORT PG_FUNCTION_INFO_V1(h3index_btequalimage);
+
+Datum
+h3index_btequalimage(PG_FUNCTION_ARGS)
+{
+	PG_RETURN_BOOL(true);
+}
+
 static int
 h3index_cmp_abbrev(Datum x, Datum y, SortSupport ssup)
 {

--- a/h3/test/expected/opclass_btree.out
+++ b/h3/test/expected/opclass_btree.out
@@ -90,3 +90,15 @@ SELECT i.idx_between > 0 FROM btree_idx_bw i;
  t
 
 DROP TABLE btree_idx_bw, btree_seq_bw;
+--
+-- TEST equalimage support function is registered
+-- Without support function 4 PostgreSQL silently disables btree
+-- deduplication for every h3index index.
+--
+SELECT COUNT(*) = 1 AS has_equalimage
+  FROM pg_amproc ap
+  JOIN pg_opfamily f ON f.oid = ap.amprocfamily
+  JOIN pg_am am ON am.oid = f.opfmethod
+ WHERE f.opfname = 'h3index_ops' AND am.amname = 'btree' AND ap.amprocnum = 4;
+ t
+

--- a/h3/test/expected/opclass_btree.out
+++ b/h3/test/expected/opclass_btree.out
@@ -99,6 +99,11 @@ SELECT COUNT(*) = 1 AS has_equalimage
   FROM pg_amproc ap
   JOIN pg_opfamily f ON f.oid = ap.amprocfamily
   JOIN pg_am am ON am.oid = f.opfmethod
- WHERE f.opfname = 'h3index_ops' AND am.amname = 'btree' AND ap.amprocnum = 4;
+  JOIN pg_proc p ON p.oid = ap.amproc
+ WHERE f.opfname = 'h3index_ops' AND am.amname = 'btree' AND ap.amprocnum = 4
+   AND p.proname = 'h3index_btequalimage'
+   AND p.prorettype = 'boolean'::regtype
+   AND ap.amproclefttype = 'h3index'::regtype
+   AND ap.amprocrighttype = 'h3index'::regtype;
  t
 

--- a/h3/test/sql/opclass_btree.sql
+++ b/h3/test/sql/opclass_btree.sql
@@ -83,3 +83,14 @@ RESET enable_bitmapscan;
 SELECT i.idx_between = s.seq_between FROM btree_idx_bw i, btree_seq_bw s;
 SELECT i.idx_between > 0 FROM btree_idx_bw i;
 DROP TABLE btree_idx_bw, btree_seq_bw;
+
+--
+-- TEST equalimage support function is registered
+-- Without support function 4 PostgreSQL silently disables btree
+-- deduplication for every h3index index.
+--
+SELECT COUNT(*) = 1 AS has_equalimage
+  FROM pg_amproc ap
+  JOIN pg_opfamily f ON f.oid = ap.amprocfamily
+  JOIN pg_am am ON am.oid = f.opfmethod
+ WHERE f.opfname = 'h3index_ops' AND am.amname = 'btree' AND ap.amprocnum = 4;

--- a/h3/test/sql/opclass_btree.sql
+++ b/h3/test/sql/opclass_btree.sql
@@ -93,4 +93,9 @@ SELECT COUNT(*) = 1 AS has_equalimage
   FROM pg_amproc ap
   JOIN pg_opfamily f ON f.oid = ap.amprocfamily
   JOIN pg_am am ON am.oid = f.opfmethod
- WHERE f.opfname = 'h3index_ops' AND am.amname = 'btree' AND ap.amprocnum = 4;
+  JOIN pg_proc p ON p.oid = ap.amproc
+ WHERE f.opfname = 'h3index_ops' AND am.amname = 'btree' AND ap.amprocnum = 4
+   AND p.proname = 'h3index_btequalimage'
+   AND p.prorettype = 'boolean'::regtype
+   AND ap.amproclefttype = 'h3index'::regtype
+   AND ap.amprocrighttype = 'h3index'::regtype;


### PR DESCRIPTION
Fixes #213. Registers support function 4 (`equalimage`) for the btree `h3index_ops` opclass, allowing PostgreSQL to deduplicate `h3index` indexes.

## Why This Is Safe

`equalimage` asserts that equality implies bitwise identity. `h3index_eq` is `a == b` on the raw 64-bit value, with no normalization, scale, or collation, and the type is declared `LIKE = int8`, so the unconditional-true form used by `btequalimage` applies. PostgreSQL omits `equalimage` only for types like `float8` and `numeric`, where equal values can differ in representation.

## Performance / Space Savings

On a table of 26.4M rows keyed by res-7 cells (~721 rows per distinct cell, a common shape when attaching many records to a coarse grid):

| index state | size |
|---|---|
| baseline (production index, includes bloat) | 830 MB |
| after `REINDEX` alone (bloat removed, no dedup) | 566 MB |
| after `REINDEX` with `equalimage` | **173 MB** |

**A 3.3x reduction on top of what a plain `REINDEX` already recovers.** The gain scales with duplication, so an index with few duplicate cells sees little or nothing (at res 15 the gains are negligible).

## Testing and Backwards Compatibility (PG 14 to 19)

`ctest` regression passes, and `pg_validate_extupgrade` from `0.1.0` to `4.5.0dev` reports no difference.

Since that only compares catalogs on an empty database, I also tested upgrades manually via Docker against databases with **existing objects and data** on PG 14, 15, 16, 17, 18, and 19beta3.

**Methodology:** Built `v4.5.0`, created a 17,150-row fixture (343 distinct res-7 cells × 50 duplicates) with a btree index, installed this branch, ran `ALTER EXTENSION`. Correctness was checked against the **old-opclass index with no `REINDEX`**, comparing each query under a forced index scan against a forced sequential scan.

**Deduplication works seamlessly.** Identical byte-for-byte results across all versions:

| | support procs | index size |
|---|---|---|
| Pre-upgrade | 1,2 | 401 KB |
| Post-`ALTER EXTENSION` | 1,2,4 | 401 KB (existing indexes safe but unchanged) |
| Post-`REINDEX` | 1,2,4 | **139 KB** |

Everything else checked, all on every version:

| Check | Coverage | Result |
|---|---|---|
| Existing index correctness | equality, 5 range operators, `ORDER BY h3` ASC/DESC, `amcheck` | 0 mismatches vs seqscan |
| Dependent objects | unique, multicolumn, expression, partial, `DESC NULLS LAST`, PK/FK, hash partitions, matviews | 0 invalid indexes |
| `pg_dump` / `pg_restore` | round trip of an upgraded database | clean |
| `pg_upgrade` | both orderings (PG first, or extension first) | pass |
| Catalog parity | upgraded vs fresh install | exact match |
| PG18 `PG_MODULE_MAGIC_EXT` | version mismatch during upgrade window | harmless |

## Policy Decision: No Automatic Reindex

Unlike #190, this is an optimization rather than a correctness fix: existing indexes remain valid and return correct results.

I recommend against automatically reindexing during `ALTER EXTENSION`:

- The upgrade currently takes no locks on affected user tables or indexes.
- Automatic reindexing would acquire `AccessExclusiveLock` on every affected B-tree index for the duration of its rebuild.
- Users can instead run `REINDEX INDEX CONCURRENTLY` when convenient, gaining the space savings without a prolonged exclusive lock.

## Review Feedback Addressed

- **Documented opt-in deduplication:** Added a `CHANGELOG.md` entry explaining that existing indexes remain correct and gain deduplication on their next `REINDEX`.
- **Strengthened the assertion:** The test now verifies through `pg_proc` that support function 4 is specifically `h3index_btequalimage`, returning `boolean` for `h3index, h3index`.

I did not add a regression test for deduplication itself because that would introduce a `pageinspect` dependency primarily to test PostgreSQL’s native behavior.

## Note for Maintainers

Upgrades from ≤4.2.3 pass through `h3--4.2.3--4.5.0.sql`, whose #190 reindex block runs before this patch registers `equalimage`. Those indexes are therefore rebuilt without deduplication and require a later manual `REINDEX` to receive the space savings.

This does not affect correctness. I am flagging it without proposing a change, since addressing it would require modifying a released upgrade path.
